### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/《大语言模型系统工程理论与实践》/chapter11/README.md
+++ b/《大语言模型系统工程理论与实践》/chapter11/README.md
@@ -32,5 +32,5 @@ if __name__ == "__main__":
 
 ## 问题记录
 
-  1. **Autogen 安装问题** ：原代码中直接使用 `pip install pyautogen` 可能无法满足官方推荐的库版本，需采用 `pip install -U "autogenstudio"` 进行安装。
+  1. **Autogen 安装问题** ：原代码中直接使用 `pip install ag2` 可能无法满足官方推荐的库版本，需采用 `pip install -U "autogenstudio"` 进行安装。
   2. **代码兼容性问题** ：原代码中的 `await Console(group_chat.run_stream(task="Plan a 3 day trip to Nepal."))` 在 Python 下运行不通，需修改为 async 函数封装的形式。


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
